### PR TITLE
Fix pluralization helper and add tests

### DIFF
--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -107,7 +107,7 @@ let shuffle = (arr) => {
 
 let compareNumbers = (a, b) => a - b
 
-const pluralize = (number, string) => number > 1 ? string + 's' : string
+const pluralize = (number, string) => number === 1 ? string : string + 's'
 
 const sample = list => list[(Math.random() * list.length)|0]
 

--- a/test/util/util.test.js
+++ b/test/util/util.test.js
@@ -37,4 +37,10 @@ describe('util', () => {
     assert.equal(Color(util.numberToColor(0xff05ff)).g, Color('#ff05ff').g)
     assert.equal(Color(util.numberToColor(0xff05ff)).b, Color('#ff05ff').b)
   })
+
+  it('pluralize', () => {
+    assert.equal(util.pluralize(0, 'item'), 'items')
+    assert.equal(util.pluralize(1, 'item'), 'item')
+    assert.equal(util.pluralize(2, 'item'), 'items')
+  })
 })


### PR DESCRIPTION
## Summary
- fix `pluralize` utility to pluralize correctly for zero and other counts
- test pluralization behavior across several counts

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a8e2cafc832b960f6d404f46157f